### PR TITLE
Support nesting of UPDATE and DELETE

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -19,6 +19,16 @@ type DeleteBuilder struct {
 
 // SQL builds the query into a SQL string and bound args.
 func (b DeleteBuilder) SQL() (sqlStr string, args []any, err error) {
+	sqlStr, args, err = b.unfinalizedSQL()
+	if err != nil {
+		return
+	}
+
+	sqlStr, err = dollarPlaceholder(sqlStr)
+	return
+}
+
+func (b DeleteBuilder) unfinalizedSQL() (sqlStr string, args []any, err error) {
 	if b.from == "" {
 		err = fmt.Errorf("delete statements must specify a From table")
 		return
@@ -75,7 +85,7 @@ func (b DeleteBuilder) SQL() (sqlStr string, args []any, err error) {
 		}
 	}
 
-	sqlStr, err = dollarPlaceholder(sql.String())
+	sqlStr = sql.String()
 	return
 }
 

--- a/update.go
+++ b/update.go
@@ -25,6 +25,16 @@ type setClause struct {
 }
 
 func (b UpdateBuilder) SQL() (sqlStr string, args []any, err error) {
+	sqlStr, args, err = b.unfinalizedSQL()
+	if err != nil {
+		return
+	}
+
+	sqlStr, err = dollarPlaceholder(sqlStr)
+	return
+}
+
+func (b UpdateBuilder) unfinalizedSQL() (sqlStr string, args []any, err error) {
 	if b.table == "" {
 		err = fmt.Errorf("update statements must specify a table")
 		return
@@ -108,7 +118,7 @@ func (b UpdateBuilder) SQL() (sqlStr string, args []any, err error) {
 		}
 	}
 
-	sqlStr, err = dollarPlaceholder(sql.String())
+	sqlStr = sql.String()
 	return
 }
 


### PR DESCRIPTION
It is already possible to build [CTEs](https://www.postgresql.org/docs/current/queries-with.html) by nesting a SelectBuilder in a prefix or suffix, thanks to the rawSQLizer interface.

This PR implements this interface for UpdateBuilder and DeleteBuilder as well, allowing for [writing CTEs](https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-MODIFYING).