### PR TITLE
Adding RemoveOrderBy to SelectBuilder

### DIFF
--- a/select.go
+++ b/select.go
@@ -288,6 +288,12 @@ func (b SelectBuilder) Having(pred any, rest ...any) SelectBuilder {
 	return b
 }
 
+// RemoveOrderBy removes ORDER BY clause.
+func (b SelectBuilder) RemoveOrderBy() SelectBuilder {
+	b.orderByParts = nil
+	return b
+}
+
 // OrderByClause adds ORDER BY clause to the query.
 func (b SelectBuilder) OrderByClause(pred any, args ...any) SelectBuilder {
 	b.orderByParts = append(b.orderByParts, newPart(pred, args...))

--- a/select_test.go
+++ b/select_test.go
@@ -38,6 +38,8 @@ func TestSelectBuilderSQL(t *testing.T) {
 		Where(Or{Expr("j = ?", 10), And{Eq{"k": 11}, Expr("true")}}).
 		GroupBy("l").
 		Having("m = n").
+		OrderBy("a ASC").
+		RemoveOrderBy().
 		OrderByClause("? DESC", 1).
 		OrderBy("o ASC", "p DESC").
 		Limit(12).


### PR DESCRIPTION
Hi there!

I'm currently facing an issue where I need to remove the OrderBy from a query.
In my use case, I'm using the query builder to remove columns, and when I do that, the OrderBy breaks.

I couldn't find way to remove the OrderBy with the builder, so I added a method to handle that.