### PR TITLE
Fix parameter numbering in ReturningSelect

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -162,6 +162,7 @@ func (b DeleteBuilder) Returning(columns ...string) DeleteBuilder {
 
 // ReturningSelect adds a RETURNING expressions to the query similar to Using, but takes a Select statement.
 func (b DeleteBuilder) ReturningSelect(from SelectBuilder, alias string) DeleteBuilder {
+	from.placeholder = questionPlaceholder
 	b.returning = append(b.returning, Alias{Expr: from, As: alias})
 	return b
 }

--- a/delete_test.go
+++ b/delete_test.go
@@ -57,9 +57,9 @@ func TestDeleteBuilderSQL(t *testing.T) {
 		},
 		{
 			name:     "returning_select",
-			b:        beginning.ReturningSelect(Select("abc").From("atable"), "something"),
-			wantSQL:  "WITH prefix AS $1 DELETE FROM a WHERE b = $2 ORDER BY c RETURNING (SELECT abc FROM atable) AS something",
-			wantArgs: []any{0, 1},
+			b:        beginning.ReturningSelect(Select("abc").From("atable").Where("d = ?", 2), "something"),
+			wantSQL:  "WITH prefix AS $1 DELETE FROM a WHERE b = $2 ORDER BY c RETURNING (SELECT abc FROM atable WHERE d = $3) AS something",
+			wantArgs: []any{0, 1, 2},
 		},
 		{
 			name:     "delete_using",

--- a/insert.go
+++ b/insert.go
@@ -192,6 +192,7 @@ func (b InsertBuilder) Returning(columns ...string) InsertBuilder {
 
 // ReturningSelect adds a RETURNING expressions to the query similar to Using, but takes a Select statement.
 func (b InsertBuilder) ReturningSelect(from SelectBuilder, alias string) InsertBuilder {
+	from.placeholder = questionPlaceholder
 	b.returning = append(b.returning, Alias{Expr: from, As: alias})
 	return b
 }

--- a/insert_test.go
+++ b/insert_test.go
@@ -74,9 +74,9 @@ func TestInsertBuilderSQL(t *testing.T) {
 				Columns("b", "c").
 				Values(1, 2).
 				Values(3, Expr("? + 1", 4)).
-				ReturningSelect(Select("abc").From("atable"), "something"),
-			wantSQL:  "INSERT INTO a (b,c) VALUES ($1,$2),($3,$4 + 1) RETURNING (SELECT abc FROM atable) AS something",
-			wantArgs: []any{1, 2, 3, 4},
+				ReturningSelect(Select("abc").From("atable").Where("d = ?", 5), "something"),
+			wantSQL:  "INSERT INTO a (b,c) VALUES ($1,$2),($3,$4 + 1) RETURNING (SELECT abc FROM atable WHERE d = $5) AS something",
+			wantArgs: []any{1, 2, 3, 4, 5},
 		},
 	}
 	for _, tc := range testCases {

--- a/update.go
+++ b/update.go
@@ -218,6 +218,7 @@ func (b UpdateBuilder) Returning(columns ...string) UpdateBuilder {
 
 // ReturningSelect adds a RETURNING expressions to the query similar to Using, but takes a Select statement.
 func (b UpdateBuilder) ReturningSelect(from SelectBuilder, alias string) UpdateBuilder {
+	from.placeholder = questionPlaceholder
 	b.returning = append(b.returning, Alias{Expr: from, As: alias})
 	return b
 }

--- a/update_test.go
+++ b/update_test.go
@@ -92,7 +92,7 @@ func TestUpdateBuilderSQL(t *testing.T) {
 		},
 		{
 			name: "returning_select",
-			b:    beginning.ReturningSelect(Select("abc").From("atable"), "something"),
+			b:    beginning.ReturningSelect(Select("abc").From("atable").Where("f = ?", 4), "something"),
 			wantSQL: "WITH prefix AS $1 " +
 				"UPDATE a SET b = $2 + 1, c = $3, " +
 				"c1 = CASE status WHEN 1 THEN 2 WHEN 2 THEN 1 END, " +
@@ -100,8 +100,8 @@ func TestUpdateBuilderSQL(t *testing.T) {
 				"c3 = (SELECT a FROM b) " +
 				"WHERE d = $6 " +
 				"ORDER BY e " +
-				"RETURNING (SELECT abc FROM atable) AS something",
-			wantArgs: []any{0, 1, 2, "foo", "bar", 3},
+				"RETURNING (SELECT abc FROM atable WHERE f = $7) AS something",
+			wantArgs: []any{0, 1, 2, "foo", "bar", 3, 4},
 		},
 		{
 			name: "from",


### PR DESCRIPTION
This PR fixes wrong parameter numbering in `ReturningSelect()`