### PR TITLE
Add first-class support for CTEs

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -8,6 +8,7 @@ import (
 
 // DeleteBuilder builds SQL DELETE statements.
 type DeleteBuilder struct {
+	ctes       []cte
 	prefixes   []SQLizer
 	from       string
 	usingParts []SQLizer
@@ -35,6 +36,13 @@ func (b DeleteBuilder) unfinalizedSQL() (sqlStr string, args []any, err error) {
 	}
 
 	sql := &bytes.Buffer{}
+
+	if len(b.ctes) > 0 {
+		args, err = appendCTEs(b.ctes, sql, args)
+		if err != nil {
+			return
+		}
+	}
 
 	if len(b.prefixes) > 0 {
 		args, err = appendSQL(b.prefixes, sql, " ", args)
@@ -107,6 +115,12 @@ func (b DeleteBuilder) Prefix(sql string, args ...any) DeleteBuilder {
 // PrefixExpr adds an expression to the very beginning of the query
 func (b DeleteBuilder) PrefixExpr(expr SQLizer) DeleteBuilder {
 	b.prefixes = append(b.prefixes, expr)
+	return b
+}
+
+// With adds a Common Table Expression (CTE) to the query.
+func (b DeleteBuilder) With(name string, expr SQLizer) DeleteBuilder {
+	b.ctes = append(b.ctes, cte{name: name, expr: expr})
 	return b
 }
 

--- a/delete.go
+++ b/delete.go
@@ -124,6 +124,12 @@ func (b DeleteBuilder) With(name string, expr SQLizer) DeleteBuilder {
 	return b
 }
 
+// WithRecursive adds a recursive Common Table Expression (CTE) to the query.
+func (b DeleteBuilder) WithRecursive(name string, expr UnionBuilder) DeleteBuilder {
+	b.ctes = append(b.ctes, cte{name: name, expr: expr, recursive: true})
+	return b
+}
+
 // From sets the table to be deleted from.
 func (b DeleteBuilder) From(from string) DeleteBuilder {
 	b.from = from

--- a/delete_test.go
+++ b/delete_test.go
@@ -73,6 +73,15 @@ func TestDeleteBuilderSQL(t *testing.T) {
 			wantSQL:  "DELETE FROM films USING (SELECT id FROM producers WHERE name = $1) AS p",
 			wantArgs: []any{"foo"},
 		},
+		{
+			name: "delete_with_cte",
+			b: Delete("orders").
+				With("old_orders", Select("id").From("orders").Where("created_at < ?", "2010-01-01")).
+				Where("id IN (SELECT id FROM old_orders)"),
+			wantSQL: "WITH old_orders AS (SELECT id FROM orders WHERE created_at < $1) " +
+				"DELETE FROM orders WHERE id IN (SELECT id FROM old_orders)",
+			wantArgs: []any{"2010-01-01"},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/delete_test.go
+++ b/delete_test.go
@@ -82,6 +82,23 @@ func TestDeleteBuilderSQL(t *testing.T) {
 				"DELETE FROM orders WHERE id IN (SELECT id FROM old_orders)",
 			wantArgs: []any{"2010-01-01"},
 		},
+		{
+			name: "delete_with_recursive_cte",
+			b: Delete("orders").
+				WithRecursive("old_orders",
+					Union(
+						Select("id").From("orders").Where("created_at < ?", "2010-01-01"),
+						Select("o.id").From("orders o").Join("old_orders r ON o.parent_id = r.id"),
+					),
+				).Where("id IN (SELECT id FROM old_orders)").
+				Returning("id"),
+			wantSQL: "WITH RECURSIVE old_orders AS " +
+				"(SELECT id FROM orders WHERE created_at < $1 " +
+				"UNION " +
+				"SELECT o.id FROM orders o JOIN old_orders r ON o.parent_id = r.id) " +
+				"DELETE FROM orders WHERE id IN (SELECT id FROM old_orders) RETURNING id",
+			wantArgs: []any{"2010-01-01"},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/expr.go
+++ b/expr.go
@@ -444,8 +444,9 @@ func isValue(v any) bool {
 }
 
 type cte struct {
-	name string
-	expr SQLizer
+	name      string
+	expr      SQLizer
+	recursive bool
 }
 
 func (c cte) unfinalizedSQL() (sql string, args []any, err error) {
@@ -458,10 +459,22 @@ func (c cte) unfinalizedSQL() (sql string, args []any, err error) {
 	return
 }
 
-// appendCTEs writes "WITH name1 AS (...), name2 AS (...) " into w and
-// accumulates bound arguments.
+// appendCTEs writes "WITH [RECURSIVE] name1 AS (...), name2 AS (...) " into w
+// and accumulates bound arguments. It emits WITH RECURSIVE when at least one
+// CTE was registered via WithRecursive.
 func appendCTEs(ctes []cte, w io.Writer, args []any) ([]any, error) {
-	io.WriteString(w, "WITH ")
+	recursive := false
+	for _, c := range ctes {
+		if c.recursive {
+			recursive = true
+			break
+		}
+	}
+	if recursive {
+		io.WriteString(w, "WITH RECURSIVE ")
+	} else {
+		io.WriteString(w, "WITH ")
+	}
 	for i, c := range ctes {
 		if i > 0 {
 			io.WriteString(w, ", ")

--- a/expr.go
+++ b/expr.go
@@ -3,6 +3,7 @@ package pgq
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"reflect"
 	"sort"
 	"strings"
@@ -440,4 +441,38 @@ func isValue(v any) bool {
 		return true
 	}
 	return false
+}
+
+type cte struct {
+	name string
+	expr SQLizer
+}
+
+func (c cte) unfinalizedSQL() (sql string, args []any, err error) {
+	var bodySQL string
+	bodySQL, args, err = nestedSQL(c.expr)
+	if err != nil {
+		return
+	}
+	sql = c.name + " AS (" + bodySQL + ")"
+	return
+}
+
+// appendCTEs writes "WITH name1 AS (...), name2 AS (...) " into w and
+// accumulates bound arguments.
+func appendCTEs(ctes []cte, w io.Writer, args []any) ([]any, error) {
+	io.WriteString(w, "WITH ")
+	for i, c := range ctes {
+		if i > 0 {
+			io.WriteString(w, ", ")
+		}
+		cteSQL, cteArgs, err := c.unfinalizedSQL()
+		if err != nil {
+			return nil, err
+		}
+		io.WriteString(w, cteSQL)
+		args = append(args, cteArgs...)
+	}
+	io.WriteString(w, " ")
+	return args, nil
 }

--- a/insert.go
+++ b/insert.go
@@ -185,6 +185,12 @@ func (b InsertBuilder) With(name string, expr SQLizer) InsertBuilder {
 	return b
 }
 
+// WithRecursive adds a recursive Common Table Expression (CTE) to the query.
+func (b InsertBuilder) WithRecursive(name string, expr UnionBuilder) InsertBuilder {
+	b.ctes = append(b.ctes, cte{name: name, expr: expr, recursive: true})
+	return b
+}
+
 // Into sets the INTO clause of the query.
 func (b InsertBuilder) Into(from string) InsertBuilder {
 	b.into = from

--- a/insert.go
+++ b/insert.go
@@ -11,6 +11,7 @@ import (
 
 // InsertBuilder builds SQL INSERT statements.
 type InsertBuilder struct {
+	ctes          []cte
 	prefixes      []SQLizer
 	verb          string
 	into          string
@@ -48,6 +49,13 @@ func (b InsertBuilder) unfinalizedSQL() (sqlStr string, args []any, err error) {
 	}
 
 	sql := &bytes.Buffer{}
+
+	if len(b.ctes) > 0 {
+		args, err = appendCTEs(b.ctes, sql, args)
+		if err != nil {
+			return
+		}
+	}
 
 	if len(b.prefixes) > 0 {
 		args, err = appendSQL(b.prefixes, sql, " ", args)
@@ -99,7 +107,7 @@ func (b InsertBuilder) unfinalizedSQL() (sqlStr string, args []any, err error) {
 		}
 	}
 
-	sqlStr, err = dollarPlaceholder(sql.String())
+	sqlStr = sql.String()
 	return
 }
 
@@ -168,6 +176,12 @@ func (b InsertBuilder) Prefix(sql string, args ...any) InsertBuilder {
 // PrefixExpr adds an expression to the very beginning of the query
 func (b InsertBuilder) PrefixExpr(expr SQLizer) InsertBuilder {
 	b.prefixes = append(b.prefixes, expr)
+	return b
+}
+
+// With adds a Common Table Expression (CTE) to the query.
+func (b InsertBuilder) With(name string, expr SQLizer) InsertBuilder {
+	b.ctes = append(b.ctes, cte{name: name, expr: expr})
 	return b
 }
 

--- a/insert.go
+++ b/insert.go
@@ -29,6 +29,15 @@ func (b InsertBuilder) Verb(v string) InsertBuilder {
 
 // SQL builds the query into a SQL string and bound args.
 func (b InsertBuilder) SQL() (sqlStr string, args []any, err error) {
+	sqlStr, args, err = b.unfinalizedSQL()
+	if err != nil {
+		return
+	}
+	sqlStr, err = dollarPlaceholder(sqlStr)
+	return
+}
+
+func (b InsertBuilder) unfinalizedSQL() (sqlStr string, args []any, err error) {
 	if b.into == "" {
 		err = errors.New("insert statements must specify a table")
 		return

--- a/insert_test.go
+++ b/insert_test.go
@@ -91,6 +91,23 @@ func TestInsertBuilderSQL(t *testing.T) {
 				"INSERT INTO products_log SELECT * FROM moved_rows",
 			wantArgs: []any{"2010-10-01", "2010-11-01"},
 		},
+		{
+			name: "recursive_cte",
+			b: Insert("archive").
+				WithRecursive("tree",
+					UnionAll(
+						Select("id", "data").From("source").Where("parent_id IS NULL"),
+						Select("s.id", "s.data").From("source s").Join("tree ON tree.id = s.parent_id"),
+					),
+				).
+				Columns("id", "data").
+				Select(Select("id", "data").From("tree")),
+			wantSQL: "WITH RECURSIVE tree AS " +
+				"(SELECT id, data FROM source WHERE parent_id IS NULL " +
+				"UNION ALL " +
+				"SELECT s.id, s.data FROM source s JOIN tree ON tree.id = s.parent_id) " +
+				"INSERT INTO archive (id,data) SELECT id, data FROM tree",
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc

--- a/insert_test.go
+++ b/insert_test.go
@@ -78,6 +78,19 @@ func TestInsertBuilderSQL(t *testing.T) {
 			wantSQL:  "INSERT INTO a (b,c) VALUES ($1,$2),($3,$4 + 1) RETURNING (SELECT abc FROM atable) AS something",
 			wantArgs: []any{1, 2, 3, 4},
 		},
+		{
+			name: "cte",
+			b: Insert("products_log").
+				With("moved_rows", Delete("products").
+					Where("date >= ?", "2010-10-01").
+					Where("date < ?", "2010-11-01").
+					Returning("*"),
+				).
+				Select(Select("*").From("moved_rows")),
+			wantSQL: "WITH moved_rows AS (DELETE FROM products WHERE date >= $1 AND date < $2 RETURNING *) " +
+				"INSERT INTO products_log SELECT * FROM moved_rows",
+			wantArgs: []any{"2010-10-01", "2010-11-01"},
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc

--- a/pgq.go
+++ b/pgq.go
@@ -1,6 +1,6 @@
 // package pgq provides a fluent SQL generator.
 //
-// See https://github.com/Masterminds/pgq for examples.
+// See https://github.com/henvic/pgq for examples.
 package pgq
 
 import (

--- a/select.go
+++ b/select.go
@@ -176,6 +176,16 @@ func (b SelectBuilder) With(name string, expr SQLizer) SelectBuilder {
 	return b
 }
 
+// WithRecursive adds a recursive Common Table Expression (CTE) to the query.
+//
+// The WITH clause will be emitted as WITH RECURSIVE whenever at least one CTE
+// is added via WithRecursive. Non-recursive CTEs added via With may appear in
+// the same clause.
+func (b SelectBuilder) WithRecursive(name string, expr UnionBuilder) SelectBuilder {
+	b.ctes = append(b.ctes, cte{name: name, expr: expr, recursive: true})
+	return b
+}
+
 // Distinct adds a DISTINCT clause to the query.
 func (b SelectBuilder) Distinct() SelectBuilder {
 	return b.Options("DISTINCT")
@@ -360,4 +370,50 @@ func (b SelectBuilder) Suffix(sql string, args ...any) SelectBuilder {
 func (b SelectBuilder) SuffixExpr(expr SQLizer) SelectBuilder {
 	b.suffixes = append(b.suffixes, expr)
 	return b
+}
+
+// UnionBuilder composes two SELECT statements with UNION or UNION ALL.
+// It implements both SQLizer and rawSQLizer so it can be used standalone or
+// as a CTE body without premature placeholder numbering.
+type UnionBuilder struct {
+	left  SelectBuilder
+	right SelectBuilder
+	all   bool
+}
+
+func (u UnionBuilder) unfinalizedSQL() (sqlStr string, args []any, err error) {
+	leftSQL, leftArgs, err := u.left.unfinalizedSQL()
+	if err != nil {
+		return
+	}
+	rightSQL, rightArgs, err := u.right.unfinalizedSQL()
+	if err != nil {
+		return
+	}
+	if u.all {
+		sqlStr = leftSQL + " UNION ALL " + rightSQL
+	} else {
+		sqlStr = leftSQL + " UNION " + rightSQL
+	}
+	args = append(leftArgs, rightArgs...)
+	return
+}
+
+func (u UnionBuilder) SQL() (sqlStr string, args []any, err error) {
+	sqlStr, args, err = u.unfinalizedSQL()
+	if err != nil {
+		return
+	}
+	sqlStr, err = dollarPlaceholder(sqlStr)
+	return
+}
+
+// Union returns a SQLizer that renders "left UNION right".
+func Union(left, right SelectBuilder) UnionBuilder {
+	return UnionBuilder{left: left, right: right, all: false}
+}
+
+// UnionAll returns a SQLizer that renders "left UNION ALL right".
+func UnionAll(left, right SelectBuilder) UnionBuilder {
+	return UnionBuilder{left: left, right: right, all: true}
 }

--- a/select.go
+++ b/select.go
@@ -9,6 +9,7 @@ import (
 // SelectBuilder builds SQL SELECT statements.
 type SelectBuilder struct {
 	placeholder  placeholder
+	ctes         []cte
 	prefixes     []SQLizer
 	options      []string
 	columns      []SQLizer
@@ -45,6 +46,13 @@ func (b SelectBuilder) unfinalizedSQL() (sqlStr string, args []any, err error) {
 	}
 
 	sql := &bytes.Buffer{}
+
+	if len(b.ctes) > 0 {
+		args, err = appendCTEs(b.ctes, sql, args)
+		if err != nil {
+			return
+		}
+	}
 
 	if len(b.prefixes) > 0 {
 		args, err = appendSQL(b.prefixes, sql, " ", args)
@@ -155,6 +163,16 @@ func (b SelectBuilder) Prefix(sql string, args ...any) SelectBuilder {
 // PrefixExpr adds an expression to the very beginning of the query
 func (b SelectBuilder) PrefixExpr(expr SQLizer) SelectBuilder {
 	b.prefixes = append(b.prefixes, expr)
+	return b
+}
+
+// With adds a Common Table Expression (CTE) to the query.
+//
+// Multiple CTEs are supported by chaining With calls; they are rendered as a
+// single WITH clause: WITH name1 AS (...), name2 AS (...).
+// CTEs are rendered before any Prefix expressions.
+func (b SelectBuilder) With(name string, expr SQLizer) SelectBuilder {
+	b.ctes = append(b.ctes, cte{name: name, expr: expr})
 	return b
 }
 

--- a/select_test.go
+++ b/select_test.go
@@ -51,16 +51,15 @@ func TestSelectBuilderSQL(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	want :=
-		"WITH prefix AS $1 " +
-			"SELECT DISTINCT a, b, c, IF(d IN ($2,$3,$4), 1, 0) as stat_column, a > $5, " +
-			"(b = ANY ($6)) AS b_alias, " +
-			"(SELECT aa, bb FROM dd) AS subq " +
-			"FROM e " +
-			"CROSS JOIN j1 JOIN j2 LEFT JOIN j3 RIGHT JOIN j4 INNER JOIN j5 CROSS JOIN j6 " +
-			"WHERE f = $7 AND g = $8 AND h = $9 AND i = ANY ($10) AND (j = $11 OR (k = $12 AND true)) " +
-			"GROUP BY l HAVING m = n ORDER BY $13 DESC, o ASC, p DESC LIMIT 12 OFFSET 13 " +
-			"FETCH FIRST $14 ROWS ONLY"
+	want := "WITH prefix AS $1 " +
+		"SELECT DISTINCT a, b, c, IF(d IN ($2,$3,$4), 1, 0) as stat_column, a > $5, " +
+		"(b = ANY ($6)) AS b_alias, " +
+		"(SELECT aa, bb FROM dd) AS subq " +
+		"FROM e " +
+		"CROSS JOIN j1 JOIN j2 LEFT JOIN j3 RIGHT JOIN j4 INNER JOIN j5 CROSS JOIN j6 " +
+		"WHERE f = $7 AND g = $8 AND h = $9 AND i = ANY ($10) AND (j = $11 OR (k = $12 AND true)) " +
+		"GROUP BY l HAVING m = n ORDER BY $13 DESC, o ASC, p DESC LIMIT 12 OFFSET 13 " +
+		"FETCH FIRST $14 ROWS ONLY"
 	if want != sql {
 		t.Errorf("expected SQL to be %q, got %q instead", want, sql)
 	}
@@ -203,7 +202,6 @@ func TestSelectBuilderNestedSelectJoin(t *testing.T) {
 func TestSelectWithOptions(t *testing.T) {
 	t.Parallel()
 	sql, _, err := Select("*").From("foo").Options("ALL").SQL()
-
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -215,7 +213,6 @@ func TestSelectWithOptions(t *testing.T) {
 func TestSelectWithRemoveLimit(t *testing.T) {
 	t.Parallel()
 	sql, _, err := Select("*").From("foo").Limit(10).RemoveLimit().SQL()
-
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -227,7 +224,6 @@ func TestSelectWithRemoveLimit(t *testing.T) {
 func TestSelectWithRemoveOffset(t *testing.T) {
 	t.Parallel()
 	sql, _, err := Select("*").From("foo").Offset(10).RemoveOffset().SQL()
-
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -242,7 +238,6 @@ func TestSelectBuilderNestedSelectDollar(t *testing.T) {
 		From("bar").Where("y = ?", 42).Suffix(")")
 	outerSQL, _, err := Select("*").
 		From("foo").Where("x = ?").Where(nestedBuilder).SQL()
-
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -464,7 +459,6 @@ func TestSelectBuilder_PrefixExpr_NestedUpdateDollar(t *testing.T) {
 		Set("x", 42).Where("x = ?", 41).Returning("*").Suffix(")")
 	outerSQL, _, err := Select("*").
 		From("updated").Where("y = ?", 11).PrefixExpr(nestedBuilder).SQL()
-
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -480,7 +474,6 @@ func TestSelectBuilder_PrefixExpr_NestedDeleteDollar(t *testing.T) {
 		Where("x = ?", 41).Returning("*").Suffix(")")
 	outerSQL, _, err := Select("*").
 		From("deleted").Where("y = ?", 11).PrefixExpr(nestedBuilder).SQL()
-
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/select_test.go
+++ b/select_test.go
@@ -582,3 +582,137 @@ func TestSelectBuilderWith(t *testing.T) {
 		})
 	}
 }
+
+func TestSelectBuilderWithRecursive(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name     string
+		b        SelectBuilder
+		wantSQL  string
+		wantArgs []any
+	}{
+		{
+			name: "recursive query",
+			b: Select("sub_part", "SUM(quantity) as total_quantity").
+				WithRecursive("included_parts(sub_part, part, quantity)", UnionAll(
+					Select("sub_part", "part", "quantity").From("parts").Where("part = ?", "our_product"),
+					Select("p.sub_part", "p.part", "p.quantity * pr.quantity").From("included_parts pr, parts p").Where("p.part = pr.sub_part"),
+				)).
+				From("included_parts").
+				GroupBy("sub_part"),
+			wantSQL: "WITH RECURSIVE included_parts(sub_part, part, quantity) AS (" +
+				"SELECT sub_part, part, quantity FROM parts WHERE part = $1 " +
+				"UNION ALL " +
+				"SELECT p.sub_part, p.part, p.quantity * pr.quantity FROM included_parts pr, parts p WHERE p.part = pr.sub_part) " +
+				"SELECT sub_part, SUM(quantity) as total_quantity FROM included_parts GROUP BY sub_part",
+			wantArgs: []any{"our_product"},
+		},
+		{
+			name: "search tree",
+			b: Select("*").
+				WithRecursive("search_tree(id, link, data)", UnionAll(
+					Select("t.id", "t.link", "t.data").From("tree t"),
+					Select("t.id", "t.link", "t.data").From("tree t, search_tree st").Where("t.id = st.link"),
+				)).
+				From("search_tree"),
+			wantSQL: "WITH RECURSIVE search_tree(id, link, data) AS (" +
+				"SELECT t.id, t.link, t.data FROM tree t " +
+				"UNION ALL " +
+				"SELECT t.id, t.link, t.data FROM tree t, search_tree st WHERE t.id = st.link" +
+				") SELECT * FROM search_tree",
+		},
+		{
+			name: "mix With and WithRecursive emits RECURSIVE",
+			b: Select("*").
+				With("base", Select("id").From("t")).
+				WithRecursive("tree",
+					UnionAll(
+						Select("id").From("nodes").Where("parent IS NULL"),
+						Select("n.id").From("nodes n").Join("tree ON tree.id = n.parent"),
+					),
+				).
+				From("tree"),
+			wantSQL: "WITH RECURSIVE " +
+				"base AS (SELECT id FROM t), " +
+				"tree AS (SELECT id FROM nodes WHERE parent IS NULL UNION ALL SELECT n.id FROM nodes n JOIN tree ON tree.id = n.parent) " +
+				"SELECT * FROM tree",
+		},
+		{
+			name: "only With calls do not emit RECURSIVE",
+			b: Select("*").
+				With("a", Select("id").From("t1")).
+				With("b", Select("id").From("t2")).
+				From("a"),
+			wantSQL: "WITH a AS (SELECT id FROM t1), b AS (SELECT id FROM t2) SELECT * FROM a",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sql, args, err := tc.b.SQL()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if sql != tc.wantSQL {
+				t.Errorf("expected SQL to be %q, got %q instead", tc.wantSQL, sql)
+			}
+			if !reflect.DeepEqual(args, tc.wantArgs) {
+				t.Errorf("expected args %v, got %v instead", tc.wantArgs, args)
+			}
+		})
+	}
+}
+
+func TestUnion(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name     string
+		u        UnionBuilder
+		wantSQL  string
+		wantArgs []any
+	}{
+		{
+			name:    "union no args",
+			u:       Union(Select("id", "name").From("customers"), Select("id", "name").From("employees")),
+			wantSQL: "SELECT id, name FROM customers UNION SELECT id, name FROM employees",
+		},
+		{
+			name:    "union all no args",
+			u:       UnionAll(Select("id", "name").From("customers"), Select("id", "name").From("employees")),
+			wantSQL: "SELECT id, name FROM customers UNION ALL SELECT id, name FROM employees",
+		},
+		{
+			name: "union with args",
+			u: Union(
+				Select("id").From("t").Where("x = ?", 1),
+				Select("id").From("t").Where("x = ?", 2),
+			),
+			wantSQL:  "SELECT id FROM t WHERE x = $1 UNION SELECT id FROM t WHERE x = $2",
+			wantArgs: []any{1, 2},
+		},
+		{
+			name: "union all with args",
+			u: UnionAll(
+				Select("id").From("t").Where("x = ?", 1),
+				Select("id").From("t").Where("x = ?", 2),
+			),
+			wantSQL:  "SELECT id FROM t WHERE x = $1 UNION ALL SELECT id FROM t WHERE x = $2",
+			wantArgs: []any{1, 2},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sql, args, err := tc.u.SQL()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if sql != tc.wantSQL {
+				t.Errorf("expected SQL to be %q, got %q instead", tc.wantSQL, sql)
+			}
+			if !reflect.DeepEqual(args, tc.wantArgs) {
+				t.Errorf("expected args %v, got %v instead", tc.wantArgs, args)
+			}
+		})
+	}
+}

--- a/select_test.go
+++ b/select_test.go
@@ -489,3 +489,96 @@ func TestSelectBuilder_PrefixExpr_NestedDeleteDollar(t *testing.T) {
 		t.Errorf("expected %q, got %v", want, outerSQL)
 	}
 }
+
+func TestSelectBuilderWith(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name     string
+		b        SelectBuilder
+		wantSQL  string
+		wantArgs []any
+	}{
+		{
+			name: "with_cte",
+			b: Select("region", "product", "SUM(quantity) AS product_units", "SUM(amount) AS product_sales").
+				With("regional_sales", Select("region", "SUM(amount) AS total_sales").
+					From("orders").
+					GroupBy("region")).
+				With("top_regions", Select("region").
+					From("regional_sales").
+					Where("total_sales > (SELECT SUM(total_sales)/10 FROM regional_sales)")).
+				From("orders").
+				Where("region IN (SELECT region FROM top_regions)").
+				GroupBy("region", "product"),
+			wantSQL: "WITH regional_sales AS (SELECT region, SUM(amount) AS total_sales FROM orders GROUP BY region), " +
+				"top_regions AS (SELECT region FROM regional_sales WHERE total_sales > (SELECT SUM(total_sales)/10 FROM regional_sales)) " +
+				"SELECT region, product, SUM(quantity) AS product_units, SUM(amount) AS product_sales " +
+				"FROM orders WHERE region IN (SELECT region FROM top_regions) GROUP BY region, product",
+			wantArgs: nil,
+		},
+		{
+			name: "cte with args",
+			b: Select("id", "total").
+				With("totals", Select("id", "SUM(amount) AS total").From("orders").Where("amount > ?", 100).GroupBy("id")).
+				From("totals").
+				Where("total > ?", 500),
+			wantSQL: "WITH totals AS (SELECT id, SUM(amount) AS total FROM orders WHERE amount > $1 GROUP BY id) " +
+				"SELECT id, total FROM totals WHERE total > $2",
+			wantArgs: []any{100, 500},
+		},
+		{
+			name: "cte body is insert returning",
+			b: Select("*").
+				With("inserted", Insert("orders").
+					Columns("region", "amount").
+					Values("West", 42).
+					Returning("id")).
+				From("inserted"),
+			wantSQL: "WITH inserted AS (INSERT INTO orders (region,amount) VALUES ($1,$2) RETURNING id) " +
+				"SELECT * FROM inserted",
+			wantArgs: []any{"West", 42},
+		},
+		{
+			name: "cte body is update returning",
+			b: Select("*").
+				With("moved", Update("old_table").Set("status", "archived").Where("id = ?", 42).Returning("*")).
+				From("moved"),
+			wantSQL: "WITH moved AS (UPDATE old_table SET status = $1 WHERE id = $2 RETURNING *) " +
+				"SELECT * FROM moved",
+			wantArgs: []any{"archived", 42},
+		},
+		{
+			name: "cte body is delete returning",
+			b: Select("*").
+				With("removed", Delete("old_table").Where("id = ?", 7).Returning("*")).
+				From("removed"),
+			wantSQL: "WITH removed AS (DELETE FROM old_table WHERE id = $1 RETURNING *) " +
+				"SELECT * FROM removed",
+			wantArgs: []any{7},
+		},
+		{
+			name: "cte with prefix coexist",
+			b: Select("*").
+				With("c", Select("id").From("t").Where("x = ?", 1)).
+				Prefix("/* hint */").
+				From("c"),
+			wantSQL:  "WITH c AS (SELECT id FROM t WHERE x = $1) /* hint */ SELECT * FROM c",
+			wantArgs: []any{1},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sql, args, err := tc.b.SQL()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if sql != tc.wantSQL {
+				t.Errorf("expected SQL to be %q, got %q instead", tc.wantSQL, sql)
+			}
+			if !reflect.DeepEqual(args, tc.wantArgs) {
+				t.Errorf("expected args %v, got %v instead", tc.wantArgs, args)
+			}
+		})
+	}
+}

--- a/update.go
+++ b/update.go
@@ -9,6 +9,7 @@ import (
 
 // UpdateBuilder builds SQL UPDATE statements.
 type UpdateBuilder struct {
+	ctes       []cte
 	prefixes   []SQLizer
 	table      string
 	setClauses []setClause
@@ -45,6 +46,13 @@ func (b UpdateBuilder) unfinalizedSQL() (sqlStr string, args []any, err error) {
 	}
 
 	sql := &bytes.Buffer{}
+
+	if len(b.ctes) > 0 {
+		args, err = appendCTEs(b.ctes, sql, args)
+		if err != nil {
+			return
+		}
+	}
 
 	if len(b.prefixes) > 0 {
 		args, err = appendSQL(b.prefixes, sql, " ", args)
@@ -140,6 +148,12 @@ func (b UpdateBuilder) Prefix(sql string, args ...any) UpdateBuilder {
 // PrefixExpr adds an expression to the very beginning of the query
 func (b UpdateBuilder) PrefixExpr(expr SQLizer) UpdateBuilder {
 	b.prefixes = append(b.prefixes, expr)
+	return b
+}
+
+// With adds a Common Table Expression (CTE) to the query.
+func (b UpdateBuilder) With(name string, expr SQLizer) UpdateBuilder {
+	b.ctes = append(b.ctes, cte{name: name, expr: expr})
 	return b
 }
 

--- a/update.go
+++ b/update.go
@@ -157,6 +157,12 @@ func (b UpdateBuilder) With(name string, expr SQLizer) UpdateBuilder {
 	return b
 }
 
+// WithRecursive adds a recursive Common Table Expression (CTE) to the query.
+func (b UpdateBuilder) WithRecursive(name string, expr UnionBuilder) UpdateBuilder {
+	b.ctes = append(b.ctes, cte{name: name, expr: expr, recursive: true})
+	return b
+}
+
 // Table sets the table to be updated.
 func (b UpdateBuilder) Table(table string) UpdateBuilder {
 	b.table = table

--- a/update_test.go
+++ b/update_test.go
@@ -136,6 +136,24 @@ func TestUpdateBuilderSQL(t *testing.T) {
 				"WHERE id IN (SELECT id FROM acme)",
 			wantArgs: []any{"Acme"},
 		},
+		{
+			name: "with_recursive_cte",
+			b: Update("employees").
+				WithRecursive("mgrs",
+					Union(
+						Select("id").From("employees").Where("manager_id IS NULL"),
+						Select("e.id").From("employees e").Join("mgrs ON mgrs.id = e.manager_id"),
+					),
+				).
+				Set("is_manager", true).
+				Where("id IN (SELECT id FROM mgrs)"),
+			wantSQL: "WITH RECURSIVE mgrs AS " +
+				"(SELECT id FROM employees WHERE manager_id IS NULL " +
+				"UNION " +
+				"SELECT e.id FROM employees e JOIN mgrs ON mgrs.id = e.manager_id) " +
+				"UPDATE employees SET is_manager = $1 WHERE id IN (SELECT id FROM mgrs)",
+			wantArgs: []any{true},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/update_test.go
+++ b/update_test.go
@@ -125,6 +125,17 @@ func TestUpdateBuilderSQL(t *testing.T) {
 				"AS acc WHERE acc.name = $1 AND employees.id = acc.sales_person",
 			wantArgs: []any{"Acme Corporation"},
 		},
+		{
+			name: "with_cte",
+			b: Update("employees").
+				With("acme", Select("id").From("accounts").Where("name = ?", "Acme")).
+				Set("sales_count", Expr("sales_count + 1")).
+				Where("id IN (SELECT id FROM acme)"),
+			wantSQL: "WITH acme AS (SELECT id FROM accounts WHERE name = $1) " +
+				"UPDATE employees SET sales_count = sales_count + 1 " +
+				"WHERE id IN (SELECT id FROM acme)",
+			wantArgs: []any{"Acme"},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Using [common table expressions](https://www.postgresql.org/docs/current/queries-with.html) with pgq is already possible with `Prefix()` and `Suffix()` calls, but can be pretty cumbersome to compose.

For example, creating this [example query](https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-SELECT)

```sql
WITH regional_sales AS (
    SELECT region, SUM(amount) AS total_sales
    FROM orders
    GROUP BY region
), top_regions AS (
    SELECT region
    FROM regional_sales
    WHERE total_sales > (SELECT SUM(total_sales)/10 FROM regional_sales)
)
SELECT region,
       product,
       SUM(quantity) AS product_units,
       SUM(amount) AS product_sales
FROM orders
WHERE region IN (SELECT region FROM top_regions)
GROUP BY region, product;
```

requires building a query like
```go
regionalSales := pgq.Select("region", "SUM(amount) AS total_sales").
		From("orders").
		GroupBy("region")
topRegions := pgq.Select("region").
		From("regional_sales").
		Where("total_sales > (SELECT SUM(total_sales)/10 FROM regional_sales)")
mainQuery := pgq.Select("region", "product", "SUM(quantity) AS product_units", "SUM(amount) AS product_sales").
	From("orders").
	Where("region IN (SELECT region FROM top_regions)").
	GroupBy("region", "product")
cte := regionalSales.Prefix("WITH regional_sales AS (").Suffix(")").
	Suffix(", top_regions AS (").SuffixExpr(topRegions).Suffix(")").
	SuffixExpr(mainQuery)
```

This PR tries to improve this by adding `With()` and `WithRecursive()` sugar methods:
```go
regionalSales := pgq.Select("region", "SUM(amount) AS total_sales").From("orders").GroupBy("region")
topRegions := pgq.Select("region").From("regional_sales").Where("total_sales > (SELECT SUM(total_sales)/10 FROM regional_sales)")
pgq.Select("region", "product", "SUM(quantity) AS product_units", "SUM(amount) AS product_sales").
	With("regional_sales", regionalSales).
	With("top_regions", topRegions).
	From("orders").
	Where("region IN (SELECT region FROM top_regions)").
	GroupBy("region", "product")
```